### PR TITLE
Added payment from Paypal

### DIFF
--- a/authorizations/authorizations.go
+++ b/authorizations/authorizations.go
@@ -3,8 +3,8 @@ package authorizations
 import (
     "fmt"
     "encoding/json"
-    "github.com/edrans/paypalrest/auth"
-    "github.com/edrans/paypalrest/common"
+    "github.com/wedancedalot/paypalrest/auth"
+    "github.com/wedancedalot/paypalrest/common"
 )
 
 type AmountDetails struct {

--- a/common/common.go
+++ b/common/common.go
@@ -4,7 +4,7 @@ import (
     "encoding/json"
     "errors"
     "fmt"
-    "github.com/edrans/paypalrest/auth"
+    "github.com/wedancedalot/paypalrest/auth"
     "io/ioutil"
     "net/http"
     "strings"

--- a/example/example.go
+++ b/example/example.go
@@ -2,8 +2,8 @@ package example
 
 import (
     "fmt"
-    "github.com/edrans/paypalrest/auth"
-    "github.com/edrans/paypalrest/payments"
+    "github.com/wedancedalot/paypalrest/auth"
+    "github.com/wedancedalot/paypalrest/payments"
 )
 
 func payWithCC() {

--- a/example/example.go
+++ b/example/example.go
@@ -52,51 +52,59 @@ func payWithCC() {
 }
 
 func payWithPaypal() {
-    auth, err := auth.NewAuth("sandbox", "your_client_id", "your_client_secret")
-    if err == nil {
-        // Save the token somewhere for later
-        token, _ := auth.GetToken()
-        fmt.Printf("\n\nAuth: %+v, Token: %+v\n\n", auth, token)
-    }
+    paymentId := r.FormValue("paymentId")
+    payerID   := r.FormValue("PayerID")
 
-    redirect_urls := payments.RedirectURL{
-        ReturnURL: "http://example.com/return_url",
-        CancelURL: "http://example.com/cancel_url",
-    }
-
-    transaction := payments.TransactionRequest{
-        Amount: payments.Amount{
-            Total:    "6.00",
-            Currency: "USD",
-            Details: payments.AmountDetails{
-                Subtotal: "6.00",
-                Tax:      "0.00",
-                Shipping: "0.00",
-            },
-        },
-        Description: "Test product",
-        ItemList: payments.ItemList{
-            Items: []payments.Item{payments.Item{
-                Quantity:   "1", 
-                Name:       "Big Red Hat", 
-                Price:      "6.00",  
-                SKU:        "sku123", 
-                Currency:   "USD",
-            }},
-        },
-    }
-
-    response, err := payments.PayWithPaypal(auth, redirect_urls, transaction)
-    if err == nil {
-        fmt.Printf("\n\n%+v\n\n", response)
-        // Redirect user to response.Links[1] which will use your ReturnUrl
-        
+    if len(paymentId) > 0 && len(payerID) > 0 { 
         // Create new auth with the token you've saved previously
-        //      auth, err := auth.NewAuthFromToken("sandbox", token)
+        //auth, err := auth.NewAuthFromToken("sandbox", token)
 
         // Get paymentId and payerId from get parameters and execute payment
-        //      payments.ExecutePaypalPayment(auth, paymentId, payerID)
+        // payments.ExecutePaypalPayment(auth, paymentId, payerID)
     } else {
-        fmt.Printf("\n\nError:\n%+v\n\n", err)
+
+        auth, err := auth.NewAuth("sandbox", "your_client_id", "your_client_secret")
+        if err == nil {
+            // Save the token somewhere for later
+            token, _ := auth.GetToken()
+            fmt.Printf("\n\nAuth: %+v, Token: %+v\n\n", auth, token)
+        }
+
+        redirect_urls := payments.RedirectURL{
+            ReturnURL: "http://example.com/return_url",
+            CancelURL: "http://example.com/cancel_url",
+        }
+
+        transaction := payments.TransactionRequest{
+            Amount: payments.Amount{
+                Total:    "6.00",
+                Currency: "USD",
+                Details: payments.AmountDetails{
+                    Subtotal: "6.00",
+                    Tax:      "0.00",
+                    Shipping: "0.00",
+                },
+            },
+            Description: "Test product",
+            ItemList: payments.ItemList{
+                Items: []payments.Item{payments.Item{
+                    Quantity:   "1", 
+                    Name:       "Big Red Hat", 
+                    Price:      "6.00",  
+                    SKU:        "sku123", 
+                    Currency:   "USD",
+                }},
+            },
+        }
+
+        response, err := payments.PayWithPaypal(auth, redirect_urls, transaction)
+        if err == nil {
+            fmt.Printf("\n\n%+v\n\n", response)
+            // Get checkout url with response.CheckoutUrl() and redirect user to it            
+            // After successful payment user will be redirected to ReturnURL with some get parameters            
+        } else {
+            fmt.Printf("\n\nError:\n%+v\n\n", err)
+        }
     }
+
 } 

--- a/example/example.go
+++ b/example/example.go
@@ -6,7 +6,7 @@ import (
     "github.com/edrans/paypalrest/payments"
 )
 
-func example() {
+func payWithCC() {
     auth, err := auth.NewAuth("sandbox", "your_client_id", "your_client_secret")
     if err == nil {
         token, _ := auth.GetToken()
@@ -51,3 +51,52 @@ func example() {
     }
 }
 
+func payWithPaypal() {
+    auth, err := auth.NewAuth("sandbox", "your_client_id", "your_client_secret")
+    if err == nil {
+        // Save the token somewhere for later
+        token, _ := auth.GetToken()
+        fmt.Printf("\n\nAuth: %+v, Token: %+v\n\n", auth, token)
+    }
+
+    redirect_urls := payments.RedirectURL{
+        ReturnURL: "http://example.com/return_url",
+        CancelURL: "http://example.com/cancel_url",
+    }
+
+    transaction := payments.TransactionRequest{
+        Amount: payments.Amount{
+            Total:    "6.00",
+            Currency: "USD",
+            Details: payments.AmountDetails{
+                Subtotal: "6.00",
+                Tax:      "0.00",
+                Shipping: "0.00",
+            },
+        },
+        Description: "Test product",
+        ItemList: payments.ItemList{
+            Items: []payments.Item{payments.Item{
+                Quantity:   "1", 
+                Name:       "Big Red Hat", 
+                Price:      "6.00",  
+                SKU:        "sku123", 
+                Currency:   "USD",
+            }},
+        },
+    }
+
+    response, err := payments.PayWithPaypal(auth, redirect_urls, transaction)
+    if err == nil {
+        fmt.Printf("\n\n%+v\n\n", response)
+        // Redirect user to response.Links[1] which will use your ReturnUrl
+        
+        // Create new auth with the token you've saved previously
+        //      auth, err := auth.NewAuthFromToken("sandbox", token)
+
+        // Get paymentId and payerId from get parameters and execute payment
+        //      payments.ExecutePaypalPayment(auth, paymentId, payerID)
+    } else {
+        fmt.Printf("\n\nError:\n%+v\n\n", err)
+    }
+} 

--- a/payments/payments.go
+++ b/payments/payments.go
@@ -109,7 +109,7 @@ type Item struct {
 
 type ItemList struct {
     Items           []Item          `json:"items,omitempty"`
-    ShippingAddress ShippingAddress `json:"shipping_address,omitempty"`
+//  ShippingAddress ShippingAddress `json:"shipping_address,omitempty"`
 }
 
 type Amount struct {
@@ -165,8 +165,9 @@ type Transaction struct {
 }
 
 type TransactionRequest struct {
-    Amount      Amount `json:"amount"`
-    Description string `json:"description"`
+    Amount      Amount      `json:"amount"`
+    Description string      `json:"description"`
+    ItemList    ItemList    `json:"item_list,omitempty"`
 }
 type RedirectURL struct {
     ReturnURL string `json:"return_url"`
@@ -180,10 +181,11 @@ type HATEOAS_Link struct {
 }
 
 type CreateRequest struct {
-    Intent       string               `json:"intent"`
-    Payer        PayerRequest         `json:"payer"`
-    Transactions []TransactionRequest `json:"transactions"`
-    RedirectURLs []RedirectURL        `json:"redirect_urls"`
+    Intent       string               `json:"intent,omitempty"`
+    Payer        PayerRequest         `json:"payer,omitempty"`
+    Transactions []TransactionRequest `json:"transactions,omitempty"`
+    RedirectURLs RedirectURL          `json:"redirect_urls,omitempty"`
+    PayerId      string               `json:"payer_id,omitempty"`
 }
 
 type CreateResponse struct {
@@ -199,25 +201,58 @@ type CreateResponse struct {
 }
 
 func PayWithCreditCard(auth *auth.PayPalAuth, credit_card CreditCard, transaction TransactionRequest) (response CreateResponse, err error) {
-    return create("sale", auth, credit_card, transaction)
-}
-
-func AuthorizeWithCreditCard(auth *auth.PayPalAuth, credit_card CreditCard, transaction TransactionRequest) (response CreateResponse, err error) {
-    return create("authorize", auth, credit_card, transaction)
-}
-
-func create(intent string, auth *auth.PayPalAuth, credit_card CreditCard, transaction TransactionRequest) (response CreateResponse, err error) {
-    var api_response []byte
-    var statusCode int
     r := CreateRequest{
-        Intent: intent,
+        Intent: "sale",
         Payer: PayerRequest{
             PaymentMethod:      "credit_card",
             FundingInstruments: []FundingInstrumentRequest{{CreditCard: credit_card}},
         },
         Transactions: []TransactionRequest{transaction},
     }
-    url := fmt.Sprintf("%s%s", auth.Endpoint, "/v1/payments/payment")
+
+    return create(auth, "/v1/payments/payment", r)
+}
+
+func AuthorizeWithCreditCard(auth *auth.PayPalAuth, credit_card CreditCard, transaction TransactionRequest) (response CreateResponse, err error) {
+    r := CreateRequest{
+        Intent: "authorize",
+        Payer: PayerRequest{
+            PaymentMethod:      "credit_card",
+            FundingInstruments: []FundingInstrumentRequest{{CreditCard: credit_card}},
+        },
+        Transactions: []TransactionRequest{transaction},
+    }
+
+    return create(auth, "/v1/payments/payment", r)
+}
+
+func PayWithPaypal(auth *auth.PayPalAuth, redirect_url RedirectURL, transaction TransactionRequest) (response CreateResponse, err error) {
+    r := CreateRequest{
+        Intent: "sale",
+        Payer: PayerRequest{
+            PaymentMethod: "paypal",
+        },
+        Transactions: []TransactionRequest{transaction},
+        RedirectURLs: redirect_url,
+    }
+
+    return create(auth, "/v1/payments/payment", r)
+}
+
+func ExecutePaypalPayment(auth *auth.PayPalAuth, paymentId, payerId string) (response CreateResponse, err error) {
+    r := CreateRequest{
+        PayerId: payerId,
+    }
+
+    return create(auth, "/v1/payments/payment/" + paymentId + "/execute/", r)
+}
+
+func create(auth *auth.PayPalAuth, url string, r CreateRequest) (response CreateResponse, err error) {
+    var api_response []byte
+    var statusCode int
+    
+    url = fmt.Sprintf("%s%s", auth.Endpoint, url)
+
     api_response, statusCode, err = common.DoRequest(auth, "POST", url, r)
     if err == nil {
         if statusCode == 201 || statusCode == 200 {

--- a/payments/payments.go
+++ b/payments/payments.go
@@ -3,8 +3,8 @@ package payments
 import (
     "encoding/json"
     "fmt"
-    "github.com/edrans/paypalrest/auth"
-    "github.com/edrans/paypalrest/common"
+    "github.com/wedancedalot/paypalrest/auth"
+    "github.com/wedancedalot/paypalrest/common"
     "time"
 )
 

--- a/payments/payments.go
+++ b/payments/payments.go
@@ -109,7 +109,7 @@ type Item struct {
 
 type ItemList struct {
     Items           []Item          `json:"items,omitempty"`
-//  ShippingAddress ShippingAddress `json:"shipping_address,omitempty"`
+    ShippingAddress *ShippingAddress `json:"shipping_address,omitempty"`
 }
 
 type Amount struct {
@@ -181,11 +181,11 @@ type HATEOAS_Link struct {
 }
 
 type CreateRequest struct {
-    Intent       string               `json:"intent,omitempty"`
-    Payer        PayerRequest         `json:"payer,omitempty"`
-    Transactions []TransactionRequest `json:"transactions,omitempty"`
-    RedirectURLs RedirectURL          `json:"redirect_urls,omitempty"`
-    PayerId      string               `json:"payer_id,omitempty"`
+    Intent       string                `json:"intent,omitempty"`
+    Payer        *PayerRequest         `json:"payer,omitempty"`
+    Transactions []TransactionRequest  `json:"transactions,omitempty"`
+    RedirectURLs *RedirectURL          `json:"redirect_urls,omitempty"`
+    PayerId      string                `json:"payer_id,omitempty"`
 }
 
 type CreateResponse struct {
@@ -203,7 +203,7 @@ type CreateResponse struct {
 func PayWithCreditCard(auth *auth.PayPalAuth, credit_card CreditCard, transaction TransactionRequest) (response CreateResponse, err error) {
     r := CreateRequest{
         Intent: "sale",
-        Payer: PayerRequest{
+        Payer: &PayerRequest{
             PaymentMethod:      "credit_card",
             FundingInstruments: []FundingInstrumentRequest{{CreditCard: credit_card}},
         },
@@ -216,7 +216,7 @@ func PayWithCreditCard(auth *auth.PayPalAuth, credit_card CreditCard, transactio
 func AuthorizeWithCreditCard(auth *auth.PayPalAuth, credit_card CreditCard, transaction TransactionRequest) (response CreateResponse, err error) {
     r := CreateRequest{
         Intent: "authorize",
-        Payer: PayerRequest{
+        Payer: &PayerRequest{
             PaymentMethod:      "credit_card",
             FundingInstruments: []FundingInstrumentRequest{{CreditCard: credit_card}},
         },
@@ -229,11 +229,11 @@ func AuthorizeWithCreditCard(auth *auth.PayPalAuth, credit_card CreditCard, tran
 func PayWithPaypal(auth *auth.PayPalAuth, redirect_url RedirectURL, transaction TransactionRequest) (response CreateResponse, err error) {
     r := CreateRequest{
         Intent: "sale",
-        Payer: PayerRequest{
+        Payer: &PayerRequest{
             PaymentMethod: "paypal",
         },
         Transactions: []TransactionRequest{transaction},
-        RedirectURLs: redirect_url,
+        RedirectURLs: &redirect_url,
     }
 
     return create(auth, "/v1/payments/payment", r)

--- a/payments/payments.go
+++ b/payments/payments.go
@@ -247,6 +247,15 @@ func ExecutePaypalPayment(auth *auth.PayPalAuth, paymentId, payerId string) (res
     return create(auth, "/v1/payments/payment/" + paymentId + "/execute/", r)
 }
 
+func (response *CreateResponse) CheckoutUrl() (url string) {
+    for _, link := range response.Links {
+        if link.Rel == "approval_url" {
+            url = link.Href
+        }
+    }    
+    return 
+}
+
 func create(auth *auth.PayPalAuth, url string, r CreateRequest) (response CreateResponse, err error) {
     var api_response []byte
     var statusCode int


### PR DESCRIPTION
Auth.go
- Created NewAuthFromToken function to create auth from saved token (in case of payment via paypal)
- Used SetEndpoint in NewAuth func

Example.go
- Added example for payment via Paypal
- Renamed functions to be informative

Payments.go
- Added pointers to several structs, for their keys to be omitted during json.marhsal and thus not to break the request.
- Added some fields to structs, which are neccessary for payment via paypal
- Added PayWithPaypal and ExecutePaypalPayment functions
- Added CheckoutUrl() method for response to get the checkout url

The '68e1285' commit was made for library to work from my fork and should not be included into pull request. 
